### PR TITLE
Filtered out carriage return from CordovaWrapper.getGlobalCordovaVersion

### DIFF
--- a/src/taco-utils/cordovaWrapper.ts
+++ b/src/taco-utils/cordovaWrapper.ts
@@ -184,7 +184,7 @@ module TacoUtility {
 
         public static getGlobalCordovaVersion(): Q.Promise<string> {
             return CordovaWrapper.cli(["-v"], true).then(function (output: string): string {
-                return output.split("\n")[0].split(" ")[0];
+                return output.replace("\r","").split("\n")[0].split(" ")[0];
             });
         }
 


### PR DESCRIPTION
removed "\r"  from being placed at the end of Cordova Version.